### PR TITLE
rename sonar project key to maintain consistency of the new…

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,4 @@
-sonar.projectKey=JHLiteCliApplication
+sonar.projectKey=JHLiteCli
 sonar.projectName=JHLite Cli
 # used for local sonarqube Docker image
 sonar.login=admin


### PR DESCRIPTION
… name JHLiteCli

- See https://github.com/jhipster/jhipster-lite/issues/11793

@murdos :
I ran sonar locally, and two issues came up. Should not use `system.out` for this command line application?

![sonar-issue](https://github.com/user-attachments/assets/2715c8c0-37b2-4752-a3f9-42317dc43cf7)

![sonar-issue_detail](https://github.com/user-attachments/assets/b2068537-a8ae-429e-a4fe-012e00ecd491)
