### PR TITLE
introduce specific parameters for each module

### DIFF
--- a/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/ApplyModuleCommand.java
+++ b/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/ApplyModuleCommand.java
@@ -40,7 +40,7 @@ class ApplyModuleCommand implements JHLiteCommand {
       .resources()
       .stream()
       .sorted(byModuleSlug())
-      .forEach(module -> spec.addSubcommand(module.slug().get(), new ModuleSlugCommand(modules, module).commandSpec()));
+      .forEach(module -> spec.addSubcommand(module.slug().get(), new ApplyModuleSubCommand(modules, module).commandSpec()));
   }
 
   private static Comparator<JHipsterModuleResource> byModuleSlug() {

--- a/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/ApplyModuleCommand.java
+++ b/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/ApplyModuleCommand.java
@@ -1,8 +1,10 @@
 package tech.jhipster.lite.cli.command.infrastructure.primary;
 
+import java.util.Comparator;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine.Model.CommandSpec;
 import tech.jhipster.lite.module.application.JHipsterModulesApplicationService;
+import tech.jhipster.lite.module.domain.resource.JHipsterModuleResource;
 
 @Component
 class ApplyModuleCommand {
@@ -31,6 +33,11 @@ class ApplyModuleCommand {
     modules
       .resources()
       .stream()
+      .sorted(byModuleSlug())
       .forEach(module -> spec.addSubcommand(module.slug().get(), new ModuleSlugCommand(modules, module).commandSpec()));
+  }
+
+  private static Comparator<JHipsterModuleResource> byModuleSlug() {
+    return Comparator.comparing(jHipsterModuleResource -> jHipsterModuleResource.slug().get());
   }
 }

--- a/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/ApplyModuleCommand.java
+++ b/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/ApplyModuleCommand.java
@@ -14,10 +14,10 @@ class ApplyModuleCommand {
   }
 
   public CommandSpec buildCommandSpec() {
-    CommandSpec commandSpec = createSpec();
-    addSubcommand(commandSpec);
+    CommandSpec spec = createSpec();
+    addModuleSlugSubcommands(spec);
 
-    return commandSpec;
+    return spec;
   }
 
   private CommandSpec createSpec() {
@@ -27,7 +27,10 @@ class ApplyModuleCommand {
     return spec;
   }
 
-  private void addSubcommand(CommandSpec commandSpec) {
-    commandSpec.addSubcommand("init", new ModuleSlugCommand(modules, "init").commandSpec());
+  private void addModuleSlugSubcommands(CommandSpec spec) {
+    modules
+      .resources()
+      .stream()
+      .forEach(module -> spec.addSubcommand(module.slug().get(), new ModuleSlugCommand(modules, module).commandSpec()));
   }
 }

--- a/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/ApplyModuleCommand.java
+++ b/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/ApplyModuleCommand.java
@@ -7,7 +7,7 @@ import tech.jhipster.lite.module.application.JHipsterModulesApplicationService;
 import tech.jhipster.lite.module.domain.resource.JHipsterModuleResource;
 
 @Component
-class ApplyModuleCommand {
+class ApplyModuleCommand implements JHLiteCommand {
 
   private final JHipsterModulesApplicationService modules;
 
@@ -15,11 +15,17 @@ class ApplyModuleCommand {
     this.modules = modules;
   }
 
-  public CommandSpec buildCommandSpec() {
+  @Override
+  public CommandSpec spec() {
     CommandSpec spec = createSpec();
     addModuleSlugSubcommands(spec);
 
     return spec;
+  }
+
+  @Override
+  public String name() {
+    return "apply";
   }
 
   private CommandSpec createSpec() {

--- a/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/ApplyModuleCommand.java
+++ b/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/ApplyModuleCommand.java
@@ -1,27 +1,13 @@
 package tech.jhipster.lite.cli.command.infrastructure.primary;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.Callable;
 import org.springframework.stereotype.Component;
-import picocli.CommandLine;
-import picocli.CommandLine.Model.ArgSpec;
 import picocli.CommandLine.Model.CommandSpec;
-import picocli.CommandLine.Model.OptionSpec;
-import picocli.CommandLine.Model.PositionalParamSpec;
 import tech.jhipster.lite.module.application.JHipsterModulesApplicationService;
-import tech.jhipster.lite.module.domain.JHipsterModuleSlug;
-import tech.jhipster.lite.module.domain.JHipsterModuleToApply;
-import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
 
 @Component
-class ApplyModuleCommand implements Callable<Integer> {
-
-  private static final String END_OF_LINE_PARAMETER = "endOfLine";
+class ApplyModuleCommand {
 
   private final JHipsterModulesApplicationService modules;
-  private CommandSpec spec;
 
   public ApplyModuleCommand(JHipsterModulesApplicationService modules) {
     this.modules = modules;
@@ -29,141 +15,19 @@ class ApplyModuleCommand implements Callable<Integer> {
 
   public CommandSpec buildCommandSpec() {
     CommandSpec commandSpec = createSpec();
-    addOptions(commandSpec);
-    addPositional(commandSpec);
-
-    this.spec = commandSpec;
+    addSubcommand(commandSpec);
 
     return commandSpec;
   }
 
   private CommandSpec createSpec() {
-    CommandSpec spec = CommandSpec.wrapWithoutInspection(this).name("apply");
+    CommandSpec spec = CommandSpec.wrapWithoutInspection(this).name("apply").mixinStandardHelpOptions(true);
     spec.usageMessage().description("Apply jhipster-lite specific module");
 
     return spec;
   }
 
-  private void addOptions(CommandSpec spec) {
-    spec.addOption(
-      OptionSpec.builder("--project-path")
-        .description("Project Path Folder")
-        .paramLabel("<projectpath>")
-        .defaultValue(".")
-        .type(String.class)
-        .build()
-    );
-
-    spec.addOption(OptionSpec.builder("--commit").description("Commit changes").negatable(true).type(Boolean.class).build());
-
-    spec.addOption(
-      OptionSpec.builder("--base-name")
-        .description("Project short name (only letters and numbers)")
-        .paramLabel("<basename>")
-        .type(String.class)
-        .required(true)
-        .build()
-    );
-
-    spec.addOption(
-      OptionSpec.builder("--project-name")
-        .description("Project full name")
-        .paramLabel("<projectname>")
-        .type(String.class)
-        .required(true)
-        .build()
-    );
-
-    spec.addOption(
-      OptionSpec.builder("--end-of-line")
-        .description("Type of line break (lf or crlf)")
-        .paramLabel("<endofline>")
-        .type(String.class)
-        .build()
-    );
-
-    spec.addOption(
-      OptionSpec.builder("--indentation")
-        .description("Number of spaces in indentation")
-        .paramLabel("<indentation>")
-        .type(Integer.class)
-        .build()
-    );
-  }
-
-  private void addPositional(CommandSpec spec) {
-    spec.addPositional(
-      PositionalParamSpec.builder()
-        .description("Module Slug to be applied")
-        .paramLabel("<moduleslug>")
-        .type(String.class)
-        .required(true)
-        .build()
-    );
-  }
-
-  @Override
-  public Integer call() {
-    String moduleSlug = moduleSlug();
-
-    JHipsterModuleProperties properties = new JHipsterModuleProperties(projectPath(), commitEnabled(), parameters());
-    JHipsterModuleToApply moduleToApply = new JHipsterModuleToApply(new JHipsterModuleSlug(moduleSlug), properties);
-    modules.apply(moduleToApply);
-
-    return CommandLine.ExitCode.OK;
-  }
-
-  private String moduleSlug() {
-    return spec.positionalParameters().getFirst().getValue();
-  }
-
-  private String projectPath() {
-    return optionValue("--project-path").map(ArgSpec::getValue).map(Object::toString).orElse(".");
-  }
-
-  private Optional<OptionSpec> optionValue(String optionName) {
-    return spec.options().stream().filter(option -> option.longestName().equals(optionName)).findFirst();
-  }
-
-  private boolean commitEnabled() {
-    return optionValue("--commit").map(ArgSpec::getValue).map(Object::toString).map(Boolean::parseBoolean).orElse(true);
-  }
-
-  private Map<String, Object> parameters() {
-    HashMap<String, Object> map = new HashMap<>();
-
-    if (baseName() != null) {
-      map.put(JHipsterModuleProperties.PROJECT_BASE_NAME_PARAMETER, baseName());
-    }
-
-    if (projectName() != null) {
-      map.put(JHipsterModuleProperties.PROJECT_NAME_PARAMETER, projectName());
-    }
-
-    if (endOfLine() != null) {
-      map.put(END_OF_LINE_PARAMETER, endOfLine());
-    }
-
-    if (indentation() != null) {
-      map.put(JHipsterModuleProperties.INDENTATION_PARAMETER, indentation());
-    }
-
-    return map;
-  }
-
-  private String projectName() {
-    return optionValue("--project-name").map(ArgSpec::getValue).map(Object::toString).orElse(null);
-  }
-
-  private String baseName() {
-    return optionValue("--base-name").map(ArgSpec::getValue).map(Object::toString).orElse(null);
-  }
-
-  private String endOfLine() {
-    return optionValue("--end-of-line").map(ArgSpec::getValue).map(Object::toString).orElse(null);
-  }
-
-  private Integer indentation() {
-    return optionValue("--indentation").map(ArgSpec::getValue).map(Object::toString).map(Integer::parseInt).orElse(null);
+  private void addSubcommand(CommandSpec commandSpec) {
+    commandSpec.addSubcommand("init", new ModuleSlugCommand(modules, "init").commandSpec());
   }
 }

--- a/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/ApplyModuleSubCommand.java
+++ b/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/ApplyModuleSubCommand.java
@@ -19,7 +19,7 @@ import tech.jhipster.lite.module.domain.resource.JHipsterModuleOperation;
 import tech.jhipster.lite.module.domain.resource.JHipsterModulePropertiesDefinition;
 import tech.jhipster.lite.module.domain.resource.JHipsterModuleResource;
 
-class ModuleSlugCommand implements Callable<Integer> {
+class ApplyModuleSubCommand implements Callable<Integer> {
 
   private static final String PROJECT_PATH_OPTION = "--project-path";
   private static final String COMMIT_OPTION = "--commit";
@@ -27,7 +27,7 @@ class ModuleSlugCommand implements Callable<Integer> {
   private final JHipsterModuleSlug moduleSlug;
   private final CommandSpec commandSpec;
 
-  public ModuleSlugCommand(JHipsterModulesApplicationService modules, JHipsterModuleResource module) {
+  public ApplyModuleSubCommand(JHipsterModulesApplicationService modules, JHipsterModuleResource module) {
     this.modules = modules;
     this.moduleSlug = module.slug();
     this.commandSpec = buildCommandSpec(module.slug(), module.apiDoc().operation(), module.propertiesDefinition());

--- a/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/JHLiteCommand.java
+++ b/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/JHLiteCommand.java
@@ -1,15 +1,26 @@
 package tech.jhipster.lite.cli.command.infrastructure.primary;
 
 import org.springframework.stereotype.Component;
-import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
 
 @Component
-@Command(
-  name = "jhlite",
-  mixinStandardHelpOptions = true,
-  subcommands = { ListModulesCommand.class, ApplyModuleCommand.class },
-  description = "JHipster Lite CLI",
-  headerHeading = "%n",
-  commandListHeading = "%nCommands:%n"
-)
-class JHLiteCommand {}
+class JHLiteCommand {
+
+  private final ListModulesCommand listModulesCommand;
+  private final ApplyModuleCommand applyModuleCommand;
+
+  public JHLiteCommand(ListModulesCommand listModulesCommand, ApplyModuleCommand applyModuleCommand) {
+    this.listModulesCommand = listModulesCommand;
+    this.applyModuleCommand = applyModuleCommand;
+  }
+
+  public CommandSpec buildCommandSpec() {
+    CommandSpec spec = CommandSpec.create().name("jhlite").mixinStandardHelpOptions(true);
+
+    spec.usageMessage().description("JHipster Lite CLI").headerHeading("%n").commandListHeading("%nCommands:%n");
+
+    spec.addSubcommand("list", listModulesCommand.buildCommandSpec());
+    spec.addSubcommand("apply", applyModuleCommand.buildCommandSpec());
+    return spec;
+  }
+}

--- a/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/JHLiteCommand.java
+++ b/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/JHLiteCommand.java
@@ -1,0 +1,9 @@
+package tech.jhipster.lite.cli.command.infrastructure.primary;
+
+import picocli.CommandLine.Model.CommandSpec;
+
+interface JHLiteCommand {
+  CommandSpec spec();
+
+  String name();
+}

--- a/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/JHLiteCommand.java
+++ b/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/JHLiteCommand.java
@@ -21,6 +21,7 @@ class JHLiteCommand {
 
     spec.addSubcommand("list", listModulesCommand.buildCommandSpec());
     spec.addSubcommand("apply", applyModuleCommand.buildCommandSpec());
+
     return spec;
   }
 }

--- a/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/JHLiteCommandRunner.java
+++ b/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/JHLiteCommandRunner.java
@@ -9,10 +9,10 @@ import tech.jhipster.lite.cli.shared.generation.domain.ExcludeFromGeneratedCodeC
 @Component
 class JHLiteCommandRunner implements CommandLineRunner, ExitCodeGenerator {
 
-  private final JHLiteCommand command;
+  private final JHLiteCommandsFactory command;
   private int exitCode;
 
-  public JHLiteCommandRunner(JHLiteCommand command) {
+  public JHLiteCommandRunner(JHLiteCommandsFactory command) {
     this.command = command;
   }
 

--- a/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/JHLiteCommandRunner.java
+++ b/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/JHLiteCommandRunner.java
@@ -4,25 +4,23 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.ExitCodeGenerator;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
-import picocli.CommandLine.IFactory;
 import tech.jhipster.lite.cli.shared.generation.domain.ExcludeFromGeneratedCodeCoverage;
 
 @Component
 class JHLiteCommandRunner implements CommandLineRunner, ExitCodeGenerator {
 
   private final JHLiteCommand command;
-  private final IFactory factory;
   private int exitCode;
 
-  public JHLiteCommandRunner(JHLiteCommand command, IFactory factory) {
+  public JHLiteCommandRunner(JHLiteCommand command) {
     this.command = command;
-    this.factory = factory;
   }
 
   @Override
   @ExcludeFromGeneratedCodeCoverage(reason = "Don not need to test when using picocli framework")
   public void run(String... args) {
-    exitCode = new CommandLine(command, factory).execute(args);
+    CommandLine commandLine = new CommandLine(command.buildCommandSpec());
+    exitCode = commandLine.execute(args);
   }
 
   @Override

--- a/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/JHLiteCommandsFactory.java
+++ b/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/JHLiteCommandsFactory.java
@@ -4,12 +4,12 @@ import org.springframework.stereotype.Component;
 import picocli.CommandLine.Model.CommandSpec;
 
 @Component
-class JHLiteCommand {
+class JHLiteCommandsFactory {
 
   private final ListModulesCommand listModulesCommand;
   private final ApplyModuleCommand applyModuleCommand;
 
-  public JHLiteCommand(ListModulesCommand listModulesCommand, ApplyModuleCommand applyModuleCommand) {
+  public JHLiteCommandsFactory(ListModulesCommand listModulesCommand, ApplyModuleCommand applyModuleCommand) {
     this.listModulesCommand = listModulesCommand;
     this.applyModuleCommand = applyModuleCommand;
   }

--- a/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/JHLiteCommandsFactory.java
+++ b/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/JHLiteCommandsFactory.java
@@ -1,17 +1,16 @@
 package tech.jhipster.lite.cli.command.infrastructure.primary;
 
+import java.util.List;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine.Model.CommandSpec;
 
 @Component
 class JHLiteCommandsFactory {
 
-  private final ListModulesCommand listModulesCommand;
-  private final ApplyModuleCommand applyModuleCommand;
+  private final List<JHLiteCommand> jhliteCommands;
 
-  public JHLiteCommandsFactory(ListModulesCommand listModulesCommand, ApplyModuleCommand applyModuleCommand) {
-    this.listModulesCommand = listModulesCommand;
-    this.applyModuleCommand = applyModuleCommand;
+  public JHLiteCommandsFactory(List<JHLiteCommand> jhliteCommands) {
+    this.jhliteCommands = jhliteCommands;
   }
 
   public CommandSpec buildCommandSpec() {
@@ -19,8 +18,7 @@ class JHLiteCommandsFactory {
 
     spec.usageMessage().description("JHipster Lite CLI").headerHeading("%n").commandListHeading("%nCommands:%n");
 
-    spec.addSubcommand("list", listModulesCommand.buildCommandSpec());
-    spec.addSubcommand("apply", applyModuleCommand.buildCommandSpec());
+    jhliteCommands.forEach(command -> spec.addSubcommand(command.name(), command.spec()));
 
     return spec;
   }

--- a/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/ListModulesCommand.java
+++ b/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/ListModulesCommand.java
@@ -5,29 +5,37 @@ import java.util.concurrent.Callable;
 import java.util.function.Consumer;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine;
-import picocli.CommandLine.ExitCode;
+import picocli.CommandLine.Model.CommandSpec;
 import tech.jhipster.lite.module.application.JHipsterModulesApplicationService;
 import tech.jhipster.lite.module.domain.JHipsterSlug;
 import tech.jhipster.lite.module.domain.resource.JHipsterModuleResource;
 import tech.jhipster.lite.module.domain.resource.JHipsterModulesResources;
 
 @Component
-@CommandLine.Command(name = "list", description = "List available jhipster-lite modules")
 class ListModulesCommand implements Callable<Integer> {
 
   private static final int MINIMAL_SPACES_BETWEEN_SLUG_AND_DESCRIPTION = 2;
+
   private final JHipsterModulesApplicationService modules;
 
   public ListModulesCommand(JHipsterModulesApplicationService modules) {
     this.modules = modules;
   }
 
+  public CommandSpec buildCommandSpec() {
+    CommandSpec spec = CommandSpec.wrapWithoutInspection(this).name("list");
+    spec.usageMessage().description("List available jhipster-lite modules");
+
+    return spec;
+  }
+
+  @Override
   public Integer call() {
     JHipsterModulesResources modulesResources = modules.resources();
     System.out.printf("Available jhipster-lite modules (%s):%n", modulesResources.stream().count());
     modulesResources.stream().sorted(byModuleSlug()).forEach(printModule(maxSlugLength(modulesResources)));
 
-    return ExitCode.OK;
+    return CommandLine.ExitCode.OK;
   }
 
   private static Comparator<JHipsterModuleResource> byModuleSlug() {

--- a/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/ListModulesCommand.java
+++ b/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/ListModulesCommand.java
@@ -4,7 +4,7 @@ import java.util.Comparator;
 import java.util.concurrent.Callable;
 import java.util.function.Consumer;
 import org.springframework.stereotype.Component;
-import picocli.CommandLine;
+import picocli.CommandLine.ExitCode;
 import picocli.CommandLine.Model.CommandSpec;
 import tech.jhipster.lite.module.application.JHipsterModulesApplicationService;
 import tech.jhipster.lite.module.domain.JHipsterSlug;
@@ -35,7 +35,7 @@ class ListModulesCommand implements Callable<Integer> {
     System.out.printf("Available jhipster-lite modules (%s):%n", modulesResources.stream().count());
     modulesResources.stream().sorted(byModuleSlug()).forEach(printModule(maxSlugLength(modulesResources)));
 
-    return CommandLine.ExitCode.OK;
+    return ExitCode.OK;
   }
 
   private static Comparator<JHipsterModuleResource> byModuleSlug() {

--- a/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/ListModulesCommand.java
+++ b/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/ListModulesCommand.java
@@ -12,7 +12,7 @@ import tech.jhipster.lite.module.domain.resource.JHipsterModuleResource;
 import tech.jhipster.lite.module.domain.resource.JHipsterModulesResources;
 
 @Component
-class ListModulesCommand implements Callable<Integer> {
+class ListModulesCommand implements JHLiteCommand, Callable<Integer> {
 
   private static final int MINIMAL_SPACES_BETWEEN_SLUG_AND_DESCRIPTION = 2;
 
@@ -22,11 +22,17 @@ class ListModulesCommand implements Callable<Integer> {
     this.modules = modules;
   }
 
-  public CommandSpec buildCommandSpec() {
+  @Override
+  public CommandSpec spec() {
     CommandSpec spec = CommandSpec.wrapWithoutInspection(this).name("list");
     spec.usageMessage().description("List available jhipster-lite modules");
 
     return spec;
+  }
+
+  @Override
+  public String name() {
+    return "list";
   }
 
   @Override

--- a/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/ModuleSlugCommand.java
+++ b/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/ModuleSlugCommand.java
@@ -6,37 +6,53 @@ import java.util.concurrent.Callable;
 import picocli.CommandLine.ExitCode;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Model.OptionSpec;
+import tech.jhipster.lite.cli.shared.error.domain.Assert;
+import tech.jhipster.lite.cli.shared.generation.domain.ExcludeFromGeneratedCodeCoverage;
 import tech.jhipster.lite.module.application.JHipsterModulesApplicationService;
 import tech.jhipster.lite.module.domain.JHipsterModuleSlug;
 import tech.jhipster.lite.module.domain.JHipsterModuleToApply;
 import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
+import tech.jhipster.lite.module.domain.properties.JHipsterPropertyDescription;
+import tech.jhipster.lite.module.domain.properties.JHipsterPropertyKey;
+import tech.jhipster.lite.module.domain.properties.JHipsterPropertyType;
+import tech.jhipster.lite.module.domain.resource.JHipsterModuleOperation;
+import tech.jhipster.lite.module.domain.resource.JHipsterModulePropertiesDefinition;
+import tech.jhipster.lite.module.domain.resource.JHipsterModuleResource;
 
 class ModuleSlugCommand implements Callable<Integer> {
 
-  private static final String END_OF_LINE_PARAMETER = "endOfLine";
-
+  private static final String PROJECT_PATH_OPTION = "--project-path";
+  private static final String COMMIT_OPTION = "--commit";
   private final JHipsterModulesApplicationService modules;
-  private final String moduleSlug;
-  private final CommandSpec spec;
+  private final JHipsterModuleSlug moduleSlug;
+  private final CommandSpec commandSpec;
 
-  public ModuleSlugCommand(JHipsterModulesApplicationService modules, String moduleSlug) {
+  public ModuleSlugCommand(JHipsterModulesApplicationService modules, JHipsterModuleResource module) {
     this.modules = modules;
-    this.moduleSlug = moduleSlug;
-    this.spec = buildCommandSpec(moduleSlug);
+    this.moduleSlug = module.slug();
+    this.commandSpec = buildCommandSpec(module.slug(), module.apiDoc().operation(), module.propertiesDefinition());
   }
 
-  private CommandSpec buildCommandSpec(String moduleSlug) {
-    CommandSpec commandSpec = CommandSpec.wrapWithoutInspection(this).name(moduleSlug).mixinStandardHelpOptions(true);
-    commandSpec.usageMessage().description("Init project");
+  private CommandSpec buildCommandSpec(
+    JHipsterModuleSlug moduleSlug,
+    JHipsterModuleOperation operation,
+    JHipsterModulePropertiesDefinition properties
+  ) {
+    CommandSpec spec = CommandSpec.wrapWithoutInspection(this).name(moduleSlug.get()).mixinStandardHelpOptions(true);
+    spec.usageMessage().description(escape(operation));
 
-    addOptions(commandSpec);
+    addOptions(spec, properties);
 
-    return commandSpec;
+    return spec;
   }
 
-  private void addOptions(CommandSpec commandSpec) {
-    commandSpec.addOption(
-      OptionSpec.builder("--project-path")
+  private String escape(JHipsterModuleOperation operation) {
+    return operation.get().replace("%", "%%");
+  }
+
+  private void addOptions(CommandSpec spec, JHipsterModulePropertiesDefinition properties) {
+    spec.addOption(
+      OptionSpec.builder(PROJECT_PATH_OPTION)
         .description("Project Path Folder")
         .paramLabel("<projectpath>")
         .defaultValue(".")
@@ -44,62 +60,83 @@ class ModuleSlugCommand implements Callable<Integer> {
         .build()
     );
 
-    commandSpec.addOption(OptionSpec.builder("--commit").description("Commit changes").negatable(true).type(Boolean.class).build());
+    spec.addOption(OptionSpec.builder(COMMIT_OPTION).description("Commit changes").negatable(true).type(Boolean.class).build());
 
-    commandSpec.addOption(
-      OptionSpec.builder("--base-name")
-        .description("Project short name (only letters and numbers)")
-        .paramLabel("<basename>")
-        .type(String.class)
-        .required(true)
-        .build()
-    );
+    properties
+      .stream()
+      .forEach(property ->
+        spec.addOption(
+          OptionSpec.builder(toDashedFormat(property.key()))
+            .description(property.description().map(JHipsterPropertyDescription::get).orElse(""))
+            .paramLabel("<%s>".formatted(property.key().get().toLowerCase()))
+            .required(property.isMandatory())
+            .type(toOptionType(property.type()))
+            .build()
+        )
+      );
+  }
 
-    commandSpec.addOption(
-      OptionSpec.builder("--project-name")
-        .description("Project full name")
-        .paramLabel("<projectname>")
-        .type(String.class)
-        .required(true)
-        .build()
-    );
+  @ExcludeFromGeneratedCodeCoverage(reason = "There is no JHipster-Lite module using a property with the BOOLEAN type")
+  private static Class<?> toOptionType(JHipsterPropertyType type) {
+    return switch (type) {
+      case BOOLEAN -> boolean.class;
+      case INTEGER -> int.class;
+      case STRING -> String.class;
+    };
+  }
 
-    commandSpec.addOption(
-      OptionSpec.builder("--end-of-line")
-        .description("Type of line break (lf or crlf)")
-        .paramLabel("<endofline>")
-        .type(String.class)
-        .build()
-    );
+  private static String toDashedFormat(JHipsterPropertyKey key) {
+    StringBuilder dashed = new StringBuilder("--");
+    for (char c : key.get().toCharArray()) {
+      if (Character.isUpperCase(c)) {
+        dashed.append('-').append(Character.toLowerCase(c));
+      } else {
+        dashed.append(c);
+      }
+    }
+    return dashed.toString();
+  }
 
-    commandSpec.addOption(
-      OptionSpec.builder("--indentation")
-        .description("Number of spaces in indentation")
-        .paramLabel("<indentation>")
-        .type(Integer.class)
-        .build()
-    );
+  private static String toCamelCaseFormat(String dashed) {
+    Assert.notBlank("dashed", dashed);
+
+    String withoutPrefix = dashed.substring(2);
+    StringBuilder camelCase = new StringBuilder();
+
+    boolean capitalizeNext = false;
+    for (char c : withoutPrefix.toCharArray()) {
+      if (c == '-') {
+        capitalizeNext = true;
+      } else if (capitalizeNext) {
+        camelCase.append(Character.toUpperCase(c));
+        capitalizeNext = false;
+      } else {
+        camelCase.append(c);
+      }
+    }
+
+    return camelCase.toString();
   }
 
   public CommandSpec commandSpec() {
-    return spec;
+    return commandSpec;
   }
 
   @Override
   public Integer call() {
     JHipsterModuleProperties properties = new JHipsterModuleProperties(projectPath(), commitEnabled(), parameters());
-    JHipsterModuleToApply moduleToApply = new JHipsterModuleToApply(new JHipsterModuleSlug(moduleSlug), properties);
+    JHipsterModuleToApply moduleToApply = new JHipsterModuleToApply(new JHipsterModuleSlug(moduleSlug.get()), properties);
     modules.apply(moduleToApply);
 
     return ExitCode.OK;
   }
 
   private String projectPath() {
-    return spec.findOption("--project-path").getValue();
+    return commandSpec.findOption(PROJECT_PATH_OPTION).getValue();
   }
 
   private boolean commitEnabled() {
-    Boolean commit = spec.findOption("--commit").getValue();
+    Boolean commit = commandSpec.findOption(COMMIT_OPTION).getValue();
 
     return commit == null || commit;
   }
@@ -107,38 +144,12 @@ class ModuleSlugCommand implements Callable<Integer> {
   private Map<String, Object> parameters() {
     HashMap<String, Object> map = new HashMap<>();
 
-    if (baseName() != null) {
-      map.put(JHipsterModuleProperties.PROJECT_BASE_NAME_PARAMETER, baseName());
-    }
-
-    if (projectName() != null) {
-      map.put(JHipsterModuleProperties.PROJECT_NAME_PARAMETER, projectName());
-    }
-
-    if (endOfLine() != null) {
-      map.put(END_OF_LINE_PARAMETER, endOfLine());
-    }
-
-    if (indentation() != null) {
-      map.put(JHipsterModuleProperties.INDENTATION_PARAMETER, indentation());
-    }
+    commandSpec
+      .options()
+      .stream()
+      .filter(option -> option.getValue() != null)
+      .forEach(option -> map.put(toCamelCaseFormat(option.longestName()), option.getValue()));
 
     return map;
-  }
-
-  private String projectName() {
-    return spec.findOption("--project-name").getValue();
-  }
-
-  private String baseName() {
-    return spec.findOption("--base-name").getValue();
-  }
-
-  private String endOfLine() {
-    return spec.findOption("--end-of-line").getValue();
-  }
-
-  private Integer indentation() {
-    return spec.findOption("--indentation").getValue();
   }
 }

--- a/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/ModuleSlugCommand.java
+++ b/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/ModuleSlugCommand.java
@@ -1,0 +1,144 @@
+package tech.jhipster.lite.cli.command.infrastructure.primary;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.ExitCode;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Model.OptionSpec;
+import tech.jhipster.lite.module.application.JHipsterModulesApplicationService;
+import tech.jhipster.lite.module.domain.JHipsterModuleSlug;
+import tech.jhipster.lite.module.domain.JHipsterModuleToApply;
+import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
+
+class ModuleSlugCommand implements Callable<Integer> {
+
+  private static final String END_OF_LINE_PARAMETER = "endOfLine";
+
+  private final JHipsterModulesApplicationService modules;
+  private final String moduleSlug;
+  private final CommandSpec spec;
+
+  public ModuleSlugCommand(JHipsterModulesApplicationService modules, String moduleSlug) {
+    this.modules = modules;
+    this.moduleSlug = moduleSlug;
+    this.spec = buildCommandSpec(moduleSlug);
+  }
+
+  private CommandSpec buildCommandSpec(String moduleSlug) {
+    CommandSpec commandSpec = CommandSpec.wrapWithoutInspection(this).name(moduleSlug).mixinStandardHelpOptions(true);
+    commandSpec.usageMessage().description("Init project");
+
+    addOptions(commandSpec);
+
+    return commandSpec;
+  }
+
+  private void addOptions(CommandSpec commandSpec) {
+    commandSpec.addOption(
+      OptionSpec.builder("--project-path")
+        .description("Project Path Folder")
+        .paramLabel("<projectpath>")
+        .defaultValue(".")
+        .type(String.class)
+        .build()
+    );
+
+    commandSpec.addOption(OptionSpec.builder("--commit").description("Commit changes").negatable(true).type(Boolean.class).build());
+
+    commandSpec.addOption(
+      OptionSpec.builder("--base-name")
+        .description("Project short name (only letters and numbers)")
+        .paramLabel("<basename>")
+        .type(String.class)
+        .required(true)
+        .build()
+    );
+
+    commandSpec.addOption(
+      OptionSpec.builder("--project-name")
+        .description("Project full name")
+        .paramLabel("<projectname>")
+        .type(String.class)
+        .required(true)
+        .build()
+    );
+
+    commandSpec.addOption(
+      OptionSpec.builder("--end-of-line")
+        .description("Type of line break (lf or crlf)")
+        .paramLabel("<endofline>")
+        .type(String.class)
+        .build()
+    );
+
+    commandSpec.addOption(
+      OptionSpec.builder("--indentation")
+        .description("Number of spaces in indentation")
+        .paramLabel("<indentation>")
+        .type(Integer.class)
+        .build()
+    );
+  }
+
+  public CommandSpec commandSpec() {
+    return spec;
+  }
+
+  @Override
+  public Integer call() {
+    JHipsterModuleProperties properties = new JHipsterModuleProperties(projectPath(), commitEnabled(), parameters());
+    JHipsterModuleToApply moduleToApply = new JHipsterModuleToApply(new JHipsterModuleSlug(moduleSlug), properties);
+    modules.apply(moduleToApply);
+
+    return ExitCode.OK;
+  }
+
+  private String projectPath() {
+    return spec.findOption("--project-path").getValue();
+  }
+
+  private boolean commitEnabled() {
+    Boolean commit = spec.findOption("--commit").getValue();
+
+    return commit == null || commit;
+  }
+
+  private Map<String, Object> parameters() {
+    HashMap<String, Object> map = new HashMap<>();
+
+    if (baseName() != null) {
+      map.put(JHipsterModuleProperties.PROJECT_BASE_NAME_PARAMETER, baseName());
+    }
+
+    if (projectName() != null) {
+      map.put(JHipsterModuleProperties.PROJECT_NAME_PARAMETER, projectName());
+    }
+
+    if (endOfLine() != null) {
+      map.put(END_OF_LINE_PARAMETER, endOfLine());
+    }
+
+    if (indentation() != null) {
+      map.put(JHipsterModuleProperties.INDENTATION_PARAMETER, indentation());
+    }
+
+    return map;
+  }
+
+  private String projectName() {
+    return spec.findOption("--project-name").getValue();
+  }
+
+  private String baseName() {
+    return spec.findOption("--base-name").getValue();
+  }
+
+  private String endOfLine() {
+    return spec.findOption("--end-of-line").getValue();
+  }
+
+  private Integer indentation() {
+    return spec.findOption("--indentation").getValue();
+  }
+}

--- a/src/test/java/tech/jhipster/lite/cli/command/infrastructure/primary/JHLiteCommandTest.java
+++ b/src/test/java/tech/jhipster/lite/cli/command/infrastructure/primary/JHLiteCommandTest.java
@@ -116,6 +116,18 @@ class JHLiteCommandTest {
     }
 
     @Test
+    void shouldDisplayModuleSlugsInAlphabeticalOrderInApplyHelpCommand(CapturedOutput output) {
+      String[] args = { "apply", "--help" };
+
+      int exitCode = commandLine().execute(args);
+
+      assertThat(exitCode).isZero();
+      assertThat(output.toString().indexOf("angular-core"))
+        .withFailMessage("Command 'angular-core' should appear before 'gradle-java' in alphabetical order")
+        .isLessThan(output.toString().indexOf("gradle-java"));
+    }
+
+    @Test
     void shouldApplyInitModuleWithRequiredOptions() throws IOException {
       Path projectPath = setupProjectTestFolder();
       String[] args = {

--- a/src/test/java/tech/jhipster/lite/cli/command/infrastructure/primary/JHLiteCommandTest.java
+++ b/src/test/java/tech/jhipster/lite/cli/command/infrastructure/primary/JHLiteCommandTest.java
@@ -76,14 +76,43 @@ class JHLiteCommandTest {
   class ApplyModule {
 
     @Test
-    void shouldNotApplyWithoutModuleSlugSubcommand(CapturedOutput output) throws IOException {
-      Path projectPath = setupProjectTestFolder();
-      String[] args = { "apply", "--project-path", projectPath.toString() };
+    void shouldNotApplyWithoutModuleSlugSubcommand(CapturedOutput output) {
+      String[] args = { "apply" };
 
       int exitCode = commandLine().execute(args);
 
       assertThat(exitCode).isEqualTo(2);
-      assertThat(output.toString()).contains("Missing required subcommand").contains("init  Init project");
+      assertThat(output.toString()).contains("Missing required subcommand").contains("init").contains("prettier");
+    }
+
+    @Test
+    void shouldEscapeCommandDescriptionInHelpCommand(CapturedOutput output) {
+      String[] args = { "apply", "--help" };
+
+      int exitCode = commandLine().execute(args);
+
+      assertThat(exitCode).isZero();
+      assertThat(output.toString()).doesNotContain(
+        "[picocli WARN] Could not format 'Add JaCoCo for code coverage reporting and 100% coverage check' (Underlying error: Conversion = c, Flags =  ). Using raw String: '%n' format strings have not been replaced with newlines. Please ensure to escape '%' characters with another '%'."
+      );
+    }
+
+    @Test
+    void shouldDisplayModuleSlugsInHelpCommand(CapturedOutput output) {
+      String[] args = { "apply", "--help" };
+
+      int exitCode = commandLine().execute(args);
+
+      assertThat(exitCode).isZero();
+      assertThat(output.toString()).contains(
+        """
+        Apply jhipster-lite specific module
+          -h, --help      Show this help message and exit.
+          -V, --version   Print version information and exit.
+        Commands:
+        """
+      );
+      assertThat(output.toString()).contains("init").contains("Init project").contains("prettier").contains("Format project with prettier");
     }
 
     @Test
@@ -221,7 +250,7 @@ class JHLiteCommandTest {
         "jhipsterSampleApplication",
         "--project-name",
         "JHipster Sample Application",
-        "--indentation",
+        "--indent-size",
         "4",
       };
 

--- a/src/test/java/tech/jhipster/lite/cli/command/infrastructure/primary/JHLiteCommandTest.java
+++ b/src/test/java/tech/jhipster/lite/cli/command/infrastructure/primary/JHLiteCommandTest.java
@@ -76,14 +76,14 @@ class JHLiteCommandTest {
   class ApplyModule {
 
     @Test
-    void shouldNotApplyWithoutModuleSlug(CapturedOutput output) throws IOException {
+    void shouldNotApplyWithoutModuleSlugSubcommand(CapturedOutput output) throws IOException {
       Path projectPath = setupProjectTestFolder();
       String[] args = { "apply", "--project-path", projectPath.toString() };
 
       int exitCode = commandLine().execute(args);
 
       assertThat(exitCode).isEqualTo(2);
-      assertThat(output.toString()).contains("Missing required").contains("'<moduleslug>'");
+      assertThat(output.toString()).contains("Missing required subcommand").contains("init  Init project");
     }
 
     @Test

--- a/src/test/java/tech/jhipster/lite/cli/command/infrastructure/primary/JHLiteCommandsFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/cli/command/infrastructure/primary/JHLiteCommandsFactoryTest.java
@@ -23,7 +23,7 @@ import tech.jhipster.lite.project.domain.history.ProjectHistory;
 
 @ExtendWith(OutputCaptureExtension.class)
 @IntegrationTest
-class JHLiteCommandTest {
+class JHLiteCommandsFactoryTest {
 
   private static final String PROJECT_NAME = "projectName";
   private static final String BASE_NAME = "baseName";
@@ -315,8 +315,8 @@ class JHLiteCommandTest {
     ListModulesCommand listModulesCommand = new ListModulesCommand(modules);
     ApplyModuleCommand applyModuleCommand = new ApplyModuleCommand(modules);
 
-    JHLiteCommand jhliteCommand = new JHLiteCommand(listModulesCommand, applyModuleCommand);
+    JHLiteCommandsFactory jhliteCommandsFactory = new JHLiteCommandsFactory(listModulesCommand, applyModuleCommand);
 
-    return new CommandLine(jhliteCommand.buildCommandSpec());
+    return new CommandLine(jhliteCommandsFactory.buildCommandSpec());
   }
 }

--- a/src/test/java/tech/jhipster/lite/cli/command/infrastructure/primary/JHLiteCommandsFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/cli/command/infrastructure/primary/JHLiteCommandsFactoryTest.java
@@ -6,6 +6,7 @@ import static tech.jhipster.lite.TestProjects.newTestFolder;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -315,7 +316,7 @@ class JHLiteCommandsFactoryTest {
     ListModulesCommand listModulesCommand = new ListModulesCommand(modules);
     ApplyModuleCommand applyModuleCommand = new ApplyModuleCommand(modules);
 
-    JHLiteCommandsFactory jhliteCommandsFactory = new JHLiteCommandsFactory(listModulesCommand, applyModuleCommand);
+    JHLiteCommandsFactory jhliteCommandsFactory = new JHLiteCommandsFactory(List.of(listModulesCommand, applyModuleCommand));
 
     return new CommandLine(jhliteCommandsFactory.buildCommandSpec());
   }


### PR DESCRIPTION
- See https://github.com/jhipster/jhipster-lite/issues/11793

DONE

- [x] use picocli programmatic api instead of annotation
- [x] define init module required and optional parameters without default values
- [x] turn init module slug into a subcommand of the apply command
- [x] create a subcommand for each jhipster-lite module with the respective properties as optional and required parameters