### PR TITLE
add version to jhlite command

### DIFF
--- a/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/JHLiteCommandsFactory.java
+++ b/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/JHLiteCommandsFactory.java
@@ -10,17 +10,27 @@ class JHLiteCommandsFactory {
 
   private final List<JHLiteCommand> jhliteCommands;
   private final String version;
+  private final String jHLiteVersion;
 
-  public JHLiteCommandsFactory(List<JHLiteCommand> jhliteCommands, @Value("${project.version:0.0.1-SNAPSHOT}") String version) {
+  public JHLiteCommandsFactory(
+    List<JHLiteCommand> jhliteCommands,
+    @Value("${project.version}") String version,
+    @Value("${project.jhlite-version}") String jHLiteVersion
+  ) {
     this.jhliteCommands = jhliteCommands;
     this.version = version;
+    this.jHLiteVersion = jHLiteVersion;
   }
 
   public CommandSpec buildCommandSpec() {
     CommandSpec spec = CommandSpec.create()
       .name("jhlite")
       .mixinStandardHelpOptions(true)
-      .version("JHipster Lite CLI v%s".formatted(version));
+      .version(
+        """
+        JHipster Lite CLI v%s
+        JHipster Lite version: %s""".formatted(version, jHLiteVersion)
+      );
 
     spec.usageMessage().description("JHipster Lite CLI").headerHeading("%n").commandListHeading("%nCommands:%n");
 

--- a/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/JHLiteCommandsFactory.java
+++ b/src/main/java/tech/jhipster/lite/cli/command/infrastructure/primary/JHLiteCommandsFactory.java
@@ -1,6 +1,7 @@
 package tech.jhipster.lite.cli.command.infrastructure.primary;
 
 import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine.Model.CommandSpec;
 
@@ -8,13 +9,18 @@ import picocli.CommandLine.Model.CommandSpec;
 class JHLiteCommandsFactory {
 
   private final List<JHLiteCommand> jhliteCommands;
+  private final String version;
 
-  public JHLiteCommandsFactory(List<JHLiteCommand> jhliteCommands) {
+  public JHLiteCommandsFactory(List<JHLiteCommand> jhliteCommands, @Value("${project.version:0.0.1-SNAPSHOT}") String version) {
     this.jhliteCommands = jhliteCommands;
+    this.version = version;
   }
 
   public CommandSpec buildCommandSpec() {
-    CommandSpec spec = CommandSpec.create().name("jhlite").mixinStandardHelpOptions(true);
+    CommandSpec spec = CommandSpec.create()
+      .name("jhlite")
+      .mixinStandardHelpOptions(true)
+      .version("JHipster Lite CLI v%s".formatted(version));
 
     spec.usageMessage().description("JHipster Lite CLI").headerHeading("%n").commandListHeading("%nCommands:%n");
 

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -3,3 +3,4 @@ spring:
     name: JHLiteCli
 project:
   version: ${project.version}
+  jhlite-version: ${jhlite.version}

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -1,3 +1,5 @@
 spring:
   application:
     name: JHLiteCli
+project:
+  version: ${project.version}

--- a/src/test/java/tech/jhipster/lite/cli/command/infrastructure/primary/JHLiteCommandsFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/cli/command/infrastructure/primary/JHLiteCommandsFactoryTest.java
@@ -344,7 +344,7 @@ class JHLiteCommandsFactoryTest {
       int exitCode = commandLine().execute(args);
 
       assertThat(exitCode).isZero();
-      assertThat(output).contains("JHipster Lite CLI v0.0.1-SNAPSHOT");
+      assertThat(output).contains("JHipster Lite CLI v1").contains("JHipster Lite version: 2");
     }
 
     private static Path setupProjectTestFolder() throws IOException {
@@ -369,10 +369,7 @@ class JHLiteCommandsFactoryTest {
     ApplyModuleSubCommandsFactory subCommandsFactory = new ApplyModuleSubCommandsFactory(modules, projects);
     ApplyModuleCommand applyModuleCommand = new ApplyModuleCommand(modules, subCommandsFactory);
 
-    JHLiteCommandsFactory jhliteCommandsFactory = new JHLiteCommandsFactory(
-      List.of(listModulesCommand, applyModuleCommand),
-      "0.0.1-SNAPSHOT"
-    );
+    JHLiteCommandsFactory jhliteCommandsFactory = new JHLiteCommandsFactory(List.of(listModulesCommand, applyModuleCommand), "1", "2");
 
     return new CommandLine(jhliteCommandsFactory.buildCommandSpec());
   }

--- a/src/test/java/tech/jhipster/lite/cli/command/infrastructure/primary/JHLiteCommandsFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/cli/command/infrastructure/primary/JHLiteCommandsFactoryTest.java
@@ -337,6 +337,16 @@ class JHLiteCommandsFactoryTest {
       assertThat(projectPropertyValue(projectPath, PACKAGE_NAME)).isEqualTo("com.my.company");
     }
 
+    @Test
+    void shouldShowVersion(CapturedOutput output) {
+      String[] args = { "--version" };
+
+      int exitCode = commandLine().execute(args);
+
+      assertThat(exitCode).isZero();
+      assertThat(output).contains("JHipster Lite CLI v0.0.1-SNAPSHOT");
+    }
+
     private static Path setupProjectTestFolder() throws IOException {
       String projectFolder = newTestFolder();
       Path projectPath = Path.of(projectFolder);
@@ -359,7 +369,10 @@ class JHLiteCommandsFactoryTest {
     ApplyModuleSubCommandsFactory subCommandsFactory = new ApplyModuleSubCommandsFactory(modules, projects);
     ApplyModuleCommand applyModuleCommand = new ApplyModuleCommand(modules, subCommandsFactory);
 
-    JHLiteCommandsFactory jhliteCommandsFactory = new JHLiteCommandsFactory(List.of(listModulesCommand, applyModuleCommand));
+    JHLiteCommandsFactory jhliteCommandsFactory = new JHLiteCommandsFactory(
+      List.of(listModulesCommand, applyModuleCommand),
+      "0.0.1-SNAPSHOT"
+    );
 
     return new CommandLine(jhliteCommandsFactory.buildCommandSpec());
   }


### PR DESCRIPTION
- Fix #20 


The command output from `jhlite --version`:
```
JHipster Lite CLI v0.0.1-SNAPSHOT
JHipster Lite version: 1.31.0
```