### PR TITLE
improve the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,41 @@ npm install
 ./mvnw
 ```
 
+## Install CLI Command
+
+```bash
+./mvnw clean package
+
+echo "java -jar \"/usr/local/bin/jhlite.jar\" \"\$@\"" | sudo tee /usr/local/bin/jhlite > /dev/null
+
+# Make the script executable
+sudo chmod +x /usr/local/bin/jhlite
+
+# Find the JAR file in the target directory and move it as jhlite.jar
+JAR_SOURCE=$(ls target/jhlite-cli-*.jar | head -n 1)
+if [ -n "$JAR_SOURCE" ]; then
+  sudo mv "$JAR_SOURCE" /usr/local/bin/jhlite.jar
+else
+  echo "No JAR file found in target directory"
+fi
+```
+
+Copy and paste the above script into a terminal to install the jhlite command.
+
+You can use a single command:
+
+```bash
+./mvnw clean package && echo "java -jar \"/usr/local/bin/jhlite.jar\" \"\$@\"" | sudo tee /usr/local/bin/jhlite > /dev/null && sudo chmod +x /usr/local/bin/jhlite && JAR_SOURCE=$(ls target/jhlite-cli-*.jar | head -n 1) && [ -n "$JAR_SOURCE" ] && sudo mv "$JAR_SOURCE" /usr/local/bin/jhlite.jar || echo "No JAR file found in target directory"
+```
+
+### Usage
+
+After the installation, you can use the `jhlite` with help command to know the options:
+
+```bash
+jhlite --help
+```
+
 <!-- jhipster-needle-startupCommand -->
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # JHLite Cli <img src="https://renanfranca.github.io/assets/icons/icon-terminal-solid-blue.svg" alt="console icon" height="20" width="20"/>
 
+## Description
+
+JHipster Lite CLI is a command-line interface tool that helps you apply and manage JHipster Lite modules. It provides a modular approach to application generation, allowing you to select specific modules and features for your project. Visit [JHipster Lite](https://github.com/jhipster/jhipster-lite) to learn more about it.
+
 ## Prerequisites
 
 ### Java

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# JHLite Cli
+# JHLite Cli <img src="https://renanfranca.github.io/assets/icons/icon-terminal-solid-blue.svg" alt="console icon" height="20" width="20"/>
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # JHipster Lite CLI <img src="https://renanfranca.github.io/assets/icons/icon-terminal-solid-blue.svg" alt="console icon" height="20" width="20"/>
 
+[![Build Status][github-actions-jhlite-lite-cli-image]][github-actions-url]
+
 ## Description
 
 JHipster Lite CLI is a command-line interface tool that helps you apply and manage JHipster Lite modules. It provides a modular approach to application generation, allowing you to select specific modules and features for your project. Visit [JHipster Lite](https://github.com/jhipster/jhipster-lite) to learn more about it.
@@ -99,3 +101,6 @@ jhlite --help
 - [sonar](documentation/sonar.md)
 
 <!-- jhipster-needle-documentation -->
+
+[github-actions-jhlite-lite-cli-image]: https://github.com/jhipster/jhipster-lite-cli/actions/workflows/github-actions.yml/badge.svg?branch=main
+[github-actions-url]: https://github.com/jhipster/jhipster-lite-cli/actions

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# JHLite Cli <img src="https://renanfranca.github.io/assets/icons/icon-terminal-solid-blue.svg" alt="console icon" height="20" width="20"/>
+# JHipster Lite CLI <img src="https://renanfranca.github.io/assets/icons/icon-terminal-solid-blue.svg" alt="console icon" height="20" width="20"/>
 
 ## Description
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ jhlite --help
 
 ## Documentation
 
+- [Commands Guide](documentation/Commands.md)
 - [Hexagonal architecture](documentation/hexagonal-architecture.md)
 - [Package types](documentation/package-types.md)
 - [Assertions](documentation/assertions.md)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,23 @@
 
 JHipster Lite CLI is a command-line interface tool that helps you apply and manage JHipster Lite modules. It provides a modular approach to application generation, allowing you to select specific modules and features for your project. Visit [JHipster Lite](https://github.com/jhipster/jhipster-lite) to learn more about it.
 
+## Quick Start
+
+You need to clone this project and go into the folder:
+
+```bash
+git clone https://github.com/jhipster/jhipster-lite
+cd jhipster-lite
+```
+
+Install `jhlite` command in your bin folder:
+
+```bash
+./mvnw clean package && echo "java -jar \"/usr/local/bin/jhlite.jar\" \"\$@\"" | sudo tee /usr/local/bin/jhlite > /dev/null && sudo chmod +x /usr/local/bin/jhlite && JAR_SOURCE=$(ls target/jhlite-cli-*.jar | head -n 1) && [ -n "$JAR_SOURCE" ] && sudo mv "$JAR_SOURCE" /usr/local/bin/jhlite.jar || echo "No JAR file found in target directory"
+```
+
+Then you can follow the [Commands Guide](documentation/Commands.md)
+
 ## Prerequisites
 
 ### Java

--- a/documentation/Commands.md
+++ b/documentation/Commands.md
@@ -1,0 +1,119 @@
+# JHipster Lite CLI Commands
+
+This document provides an overview of the JHipster Lite CLI commands available in this project.
+
+## Table of Contents
+
+- [Getting Started](#getting-started)
+- [Basic Commands](#basic-commands)
+  - [Version](#version)
+  - [List Available Modules](#list-available-modules)
+  - [Apply a Module](#apply-a-module)
+- [Project Creation Workflow Example](#project-creation-workflow-example)
+- [Options and Parameters](#options-and-parameters)
+
+## Getting Started
+
+To use JHipster Lite CLI, make sure it's installed and available in your PATH. You can check if it's properly installed with:
+
+```bash
+jhlite --version
+```
+
+## Basic Commands
+
+### Version
+
+To check the JHipster Lite CLI version:
+
+```bash
+jhlite --version
+```
+
+This will display the JHipster Lite CLI version and the JHipster Lite server version.
+
+### List Available Modules
+
+To see all available modules that can be applied to your project:
+
+```bash
+jhlite list
+```
+
+This command displays a list of all available modules with their names and descriptions.
+
+### Apply a Module
+
+To apply a specific module to your project:
+
+```bash
+jhlite apply <module-name> [options]
+```
+
+Most modules require specific parameters. If you miss required parameters, the CLI will inform you which ones are missing.
+
+To see the specific parameters for a module and which one is required, run:
+
+```bash
+jhlite apply <module-name> --help
+```
+
+## Project Creation Workflow Example
+
+A typical workflow to initialize a new project might look like:
+
+1. Create a project directory and navigate to it:
+
+   ```bash
+   mkdir my-project
+   cd my-project
+   ```
+
+2. Initialize a new project:
+
+   ```bash
+   jhlite apply init --project-name "My Project" --base-name MyProject
+   ```
+
+3. Add code formatting support:
+
+   ```bash
+   jhlite apply prettier
+   ```
+
+4. Set up a Maven project structure:
+
+   ```bash
+   jhlite apply maven-java --package-name com.example.myproject
+   ```
+
+5. Add Maven wrapper:
+
+   ```bash
+   jhlite apply maven-wrapper
+   ```
+
+6. Add Java base classes:
+
+   ```bash
+   jhlite apply java-base
+   ```
+
+7. Add Spring Boot:
+   ```bash
+   jhlite apply spring-boot
+   ```
+
+After this basic setup, you can add more specific modules based on your project requirements.
+
+## Options and Parameters
+
+Most commands accept additional options and parameters:
+
+- `--project-path=<projectpath>`: Specifies the project directory (defaults to current directory)
+- `--[no-]commit`: Whether to commit changes to git (defaults to true)
+- `--project-name=<projectname>`: The full project name (required for some modules)
+- `--base-name=<basename>`: The project's short name, used for naming files and classes (only letters and numbers allowed)
+- `--package-name=<packagename>`: The base Java package (required for Java projects)
+
+Options are module-specific. When a required option is missing, the CLI will show an error message indicating which option is required.


### PR DESCRIPTION
- Fix #11 

DONE

- [x] Add examples and introduce the `--help` command.
- [x] Create a script to generate the .jar file using mvnw, then copy the generated .jar file to the bin directory. Simplify the execution by allowing the user to type only `jhlite list`, `jhlite apply init` at the command line.
- [x] Add build status 
- [x] Add Description section
- [x] Add Quick guide section
